### PR TITLE
Using StringOps(key) when going via HttpServer

### DIFF
--- a/src/main/scala/com/walmartlabs/mupd8/Mupd8Main.scala
+++ b/src/main/scala/com/walmartlabs/mupd8/Mupd8Main.scala
@@ -1096,7 +1096,7 @@ class AppRuntime(appID: Int,
   private val threadVect: Vector[TLS] = (threadMap map { _._2 })(breakOut)
 
   def getSlate(key: (String, Key)) = {
-    assert(pool.getDestinationHost(PerformerPacket.getKey(app.performerName2ID(key._1), key._2)) == pool.cluster.self)
+    assert(pool.getDestinationHost(new StringOps(PerformerPacket.getKey(app.performerName2ID(key._1), key._2))) == pool.cluster.self)
     val future = new Later[Slate]
     getTLS(app.performerName2ID(key._1), key._2).slateCache.waitForSlate(key, future.set(_))
     Option(future.get())
@@ -1141,7 +1141,7 @@ class AppRuntime(appID: Int,
       } else {
         val key: (String, Key) = (tok(4), tok(5).map(_.toByte).toArray)
         val poolKey = PerformerPacket.getKey(app.performerName2ID(key._1), key._2)
-        val dest = pool.getDestinationHost(poolKey)
+        val dest = pool.getDestinationHost(new StringOps(poolKey))
         if (pool.cluster.self == dest)
           getSlate(key)
         else {


### PR DESCRIPTION
A continuation of the previous hashing_fix - I had missed making these changes.

Previous Change:
https://github.com/walmartlabs/mupd8/commit/09c9a3080c080248a3bc034082ce620b634a50d6

Aim was to wrap a String key by a StringOps wrapper before computing hash value (to detect which machine to send the key to).
Previous merge did it only when mappers tried to publish.
This merge applies the wrapper when an HTTP lookup is done to get the slate.
