### PR TITLE
logging: redirect test output and modify test messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,7 @@
             <exclude>**/TestAppTest.class</exclude>
             <exclude>**/RunCassServerTest.class</exclude>
           </excludes>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/scala/com/walmartlabs/mupd8/MessageServer.scala
+++ b/src/main/scala/com/walmartlabs/mupd8/MessageServer.scala
@@ -132,9 +132,9 @@ class MessageServerThread(val port : Int) extends Logging {
   val pool : ExecutorService = Executors.newCachedThreadPool()
   var ssocket : ServerSocket = null
   def run() = {
-    info("Server attempts to listen to port: " + port)
+    info("Message server attempts to listen to port: " + port)
     ssocket = new ServerSocket(port)
-    info("Server started, listening at port: " + port)
+    info("Message server started, listening at port: " + port)
     try {
       while (true) {
         val csocket = ssocket.accept()
@@ -144,7 +144,7 @@ class MessageServerThread(val port : Int) extends Logging {
   }
 
   def shutdown() = {
-    info("Shutting down...")
+    info("Message server shutting down...")
     try {
       ssocket.close
       pool.shutdown

--- a/src/main/scala/com/walmartlabs/mupd8/Mupd8Main.scala
+++ b/src/main/scala/com/walmartlabs/mupd8/Mupd8Main.scala
@@ -201,9 +201,9 @@ class MUCluster[T <: MapUpdateClass[T]](private var _hosts: Array[(String, Int)]
           if (client.isConnected(i.toString))
             info("Connected to " + i + " " + host + ":" + port)
           else {
-            if (msClient != null)
-             msClient.sendMessage(new NodeFailureMessage(getIPAddress(hosts(i)._1)))
             warn("Failed to connect to" + i + " " + host + ":" + port)
+            if (msClient != null)
+              msClient.sendMessage(new NodeFailureMessage(getIPAddress(hosts(i)._1)))
           }
         }
     }
@@ -212,9 +212,9 @@ class MUCluster[T <: MapUpdateClass[T]](private var _hosts: Array[(String, Int)]
   def send(dest: Int, obj: T) {
     assert(dest < hosts.size)
     if (!client.send(dest.toString, obj)) {
+      warn("Failed to send message to destination " + dest)
       if (msClient != null)
         msClient.sendMessage(new NodeFailureMessage(getIPAddress(hosts(dest)._1)))
-        warn("Failed to send message to destination " + dest)
     }
   }
 }

--- a/src/test/scala/com/walmartlabs/mupd8/MiscMTest.scala
+++ b/src/test/scala/com/walmartlabs/mupd8/MiscMTest.scala
@@ -36,27 +36,24 @@ class MiscMTest extends FunSuite {
 
   test("localIPAddresses") {
     val localhostIp = InetAddress.getByName("localhost").getHostAddress
-    assertTrue(localIPAddresses.exists(_ == localhostIp))
+    assertTrue("localhost address should exist", localIPAddresses.exists(_ == localhostIp))
   }
 
   test("CompressionAndUncompression") {
     val testStr = "abcd" * 1000
-    println("test snappy")
     val snappy = CompressionFactory.getService("snappy")
     val snappied = snappy.compress(testStr.getBytes)
     val unsnappied = snappy.uncompress(snappied)
-    assertTrue(testStr == new String(unsnappied))
+    assertTrue("Snappy should not mutate content", testStr == new String(unsnappied))
     
-    println("test gzip")
     val gzip = CompressionFactory.getService("gzip")
     val gzipd = gzip.compress(testStr.getBytes)
     val ungziped = gzip.uncompress(gzipd)
-    assertTrue(testStr == new String(ungziped))
+    assertTrue("gzip should not mutate content", testStr == new String(ungziped))
     
-    println("test non compression")
     val nocomp = CompressionFactory.getService("nocompression")
     val nocomped = nocomp.compress(testStr.getBytes)
-    assertTrue(testStr == new String(nocomped))
+    assertTrue("non should not mutate content", testStr == new String(nocomped))
   }
 
 }


### PR DESCRIPTION
This patch continues my previous work on log4j logging.  Outputs for std.out, std.err and log4j during the tests are redirected to local files in target/surefire-reports.  Refactor some tests and make the printout more clear.
