### PR TITLE
Updated quickstart.xml for new component versions and add'l instructions

### DIFF
--- a/src/docbook/quickstart.xml
+++ b/src/docbook/quickstart.xml
@@ -366,7 +366,7 @@ public class Counter implements Updater {
         try {
             submitter.replaceSlate(updatedSlate);
         } catch (SlateSizeException e) {
-            System.err.println("Slate update for slate ["+updatedSlate+"] failed.");
+            logger.error("Slate update for slate ["+ new String(slate, charset) +"] failed.");
         }
     }
 }


### PR DESCRIPTION
Overall this addresses natural changes in the environment since the last update that now prevent the example from running as intended. The most notable environment changes are the release of OS X 10.9 Mavericks, updates to Cassandra, and changes in upstream dependencies.

Added instructions for installing:
 -Java
 -Git
 -Maven

Updated instructions for:
 -Installing Cassandra
 -Writing the sample Mupd8 application

Fixed:
 -Potential bug in the Counter (updater) of the sample application that would bypass the logger for error output and write a memory address rather than Slate name into the error message.
