### PR TITLE
Updated Apache URLs and tweaked Cassandra instructions for clarity

### DIFF
--- a/src/docbook/quickstart.xml
+++ b/src/docbook/quickstart.xml
@@ -163,9 +163,14 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.51-b03, mixed mode)</computeroutput>
 </screen>
     </para>
     <para>
-      Configure Cassandra to write in the local directory (which does not require root as writing in /var would):
+      Decompress the file:
 <screen>
 <prompt>$</prompt> <userinput>tar xf apache-cassandra-2.0.6-bin.tar.gz</userinput>
+</screen>
+    </para>
+    <para>
+      Configure Cassandra to write in the local directory (which does not require root as writing in /var would):
+<screen>
 <prompt>$</prompt> <userinput>sed -i.original "s#/var#$PWD/var#" apache-cassandra-2.0.6/conf/{cassandra.yaml,log4j-server.properties}</userinput>
 </screen>
     </para>


### PR DESCRIPTION
Changed:
 -Updated the URLs to Apache to link directly to the Apache archive. Minor version bumps aren't stored in mirrors and quickly rendering this guide unusable
 -Separated the decompression step of the Cassandra install to clarify the actions being taken in each step of the instal
