### PR TITLE
Quickstart: Fix workflow issue from last update with Maven download (apply to html)

### DIFF
--- a/quickstart.html
+++ b/quickstart.html
@@ -99,7 +99,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 24.51-b03, mixed mode)</code>
       <p>
           To install Maven globally for your system, start by downloading Maven from an Apache mirror
 </p><pre class="screen">
-<code class="prompt">$</code> <strong class="userinput"><code>curl -L 'http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.5-bin.tar.gz' -O</code></strong>
+<code class="prompt">$</code> <strong class="userinput"><code>(cd /usr/share &amp;&amp; sudo curl -L 'http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.5-bin.tar.gz' -O)</code></strong>
 </pre><p>
       </p>
       <p>


### PR DESCRIPTION
Applies PR 51 to the rendered HTML version of the quick start guide.

From PR 51:
The last update to the quick start guide changed how the guide downloaded Maven, and did not place the downloaded file in the same place as the old instructions.

This update places the file back in the original directory.
