### PR TITLE
Move maven test dependencies to test scope.  ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,18 @@
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.10</artifactId>
       <version>1.9.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>1.9.5</version>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-actors</artifactId>
+      <version>2.10.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.netty</groupId>
@@ -114,15 +121,16 @@
       </exclusions>
     </dependency>
     <dependency>
-        <groupId>org.apache.curator</groupId>
-        <artifactId>curator-test</artifactId>
-        <version>2.3.0</version>
-          <exclusions>
-              <exclusion>
-                  <groupId>org.slf4j</groupId>
-                  <artifactId>slf4j-log4j12</artifactId>
-              </exclusion>
-          </exclusions>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>2.3.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
       </dependency>
     <dependency>
       <groupId>org.apache.cassandra</groupId>


### PR DESCRIPTION
- Move maven test dependencies to test scope
- Added explicit scala-actors dependency to replace dependency that was being received transitively from scala-test.

Still TODO would be to unify all of the scala library versions, but I didn't want to mess with that for the purpose of this PR.
